### PR TITLE
Use compressed secp256k1 public key encoding

### DIFF
--- a/src/secp256k1.rs
+++ b/src/secp256k1.rs
@@ -144,7 +144,7 @@ impl DIDCore for Secp256k1KeyPair {
 impl Fingerprint for Secp256k1KeyPair {
     fn fingerprint(&self) -> String {
         let codec: &[u8] = &[0xe7, 0x1];
-        let data = [codec, self.public_key.serialize().as_ref()].concat();
+        let data = [codec, self.public_key.serialize_compressed().as_ref()].concat();
         format!("z{}", bs58::encode(data).into_string())
     }
 }
@@ -172,7 +172,7 @@ pub mod test {
     #[test]
     fn generate_key() {
         let key_pair = Secp256k1KeyPair::new_with_seed(vec![].as_slice());
-        assert_eq!(key_pair.public_key.serialize().len(), 65);
+        assert_eq!(key_pair.public_key.serialize_compressed().len(), 33);
     }
 
     #[test]


### PR DESCRIPTION
https://docs.rs/libsecp256k1/0.3.5/secp256k1/struct.PublicKey.html#method.serialize_compressed

The (non-normative) [examples](https://w3c-ccg.github.io/did-method-key/#secp256k1) in `did:key` use the compressed form.