### PR TITLE
Update p256 key with correct fingerprint encoding based on test vectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ libsecp256k1 = "0.3.5"
 funty = "=1.1.0" # TODO: Remove this, once issue is fixed https://github.com/bitvecto-rs/bitvec/issues/105. Required for `cargo publish`
 
 [dependencies.p256]
-version = "0.5.2"
+version = "0.9.0"
 features = ["ecdsa", "ecdh"]
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ impl TryFrom<&str> for KeyPair {
             [0xed, 0x1] => KeyPair::Ed25519(Ed25519KeyPair::from_public_key(&pub_key[2..])),
             [0xec, 0x1] => KeyPair::X25519(X25519KeyPair::from_public_key(&pub_key[2..])),
             [0xee, 0x1] => KeyPair::Bls12381G1G2(Bls12381KeyPair::from_public_key(&pub_key[2..])),
-            [0x12, 0x0] => KeyPair::P256(P256KeyPair::from_public_key(&pub_key[3..])),
+            [0x80, 0x24] => KeyPair::P256(P256KeyPair::from_public_key(&pub_key[2..])),
             [0xe7, 0x0] => KeyPair::Secp256k1(Secp256k1KeyPair::from_public_key(&pub_key[2..])),
             _ => unimplemented!("unsupported key type"),
         });

--- a/src/p256.rs
+++ b/src/p256.rs
@@ -5,12 +5,12 @@ use crate::{
     AsymmetricKey, Document, Error, KeyPair, Payload, VerificationMethod,
 };
 use p256::{
-    ecdsa::{signature::Signer, signature::Verifier, Signature, SigningKey, VerifyKey},
-    EncodedPoint,
+    ecdsa::{signature::Signer, signature::Verifier, Signature, SigningKey, VerifyingKey},
+    CompressedPoint, EncodedPoint,
 };
 use std::convert::TryFrom;
 
-pub type P256KeyPair = AsymmetricKey<VerifyKey, SigningKey>;
+pub type P256KeyPair = AsymmetricKey<VerifyingKey, SigningKey>;
 
 impl std::fmt::Debug for P256KeyPair {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -22,11 +22,11 @@ impl Generate for P256KeyPair {
     fn new_with_seed(seed: &[u8]) -> Self {
         let secret_seed = generate_seed(&seed.to_vec()).expect("invalid seed");
 
-        let sk = SigningKey::new(&secret_seed).expect("Couldn't create key");
-        let pk = VerifyKey::from(&sk);
+        let sk = SigningKey::from_bytes(&secret_seed).expect("Couldn't create key");
+        let pk = VerifyingKey::from(&sk);
 
         P256KeyPair {
-            public_key: pk, //.to_encoded_point(false),
+            public_key: pk,
             secret_key: Some(sk),
         }
     }
@@ -40,9 +40,11 @@ impl Generate for P256KeyPair {
                 pkk
             }
         };
+        let cp = CompressedPoint::from_slice(public_key);
+        let pp = EncodedPoint::from_bytes(public_key);
         P256KeyPair {
-            secret_key: None, //.to_encoded_point(false),
-            public_key: VerifyKey::from_encoded_point(&EncodedPoint::from_bytes(pk.as_slice()).expect("invalid key"))
+            secret_key: None,
+            public_key: VerifyingKey::from_encoded_point(&EncodedPoint::from_bytes(public_key).expect("invalid key"))
                 .expect("invalid point"),
         }
     }
@@ -52,11 +54,11 @@ impl Generate for P256KeyPair {
     }
 
     fn from_secret_key(secret_key_bytes: &[u8]) -> Self {
-        let sk = SigningKey::new(&secret_key_bytes).expect("couldn't initialize secret key");
-        let pk = VerifyKey::from(&sk);
+        let sk = SigningKey::from_bytes(&secret_key_bytes).expect("couldn't initialize secret key");
+        let pk = VerifyingKey::from(&sk);
 
         P256KeyPair {
-            public_key: pk, //.to_encoded_point(false),
+            public_key: pk,
             secret_key: Some(sk),
         }
     }
@@ -64,7 +66,7 @@ impl Generate for P256KeyPair {
 
 impl KeyMaterial for P256KeyPair {
     fn public_key_bytes(&self) -> Vec<u8> {
-        self.public_key.to_encoded_point(false).as_bytes().to_vec()
+        self.public_key.to_encoded_point(true).as_bytes().to_vec()
     }
 
     fn private_key_bytes(&self) -> Vec<u8> {
@@ -156,8 +158,8 @@ impl DIDCore for P256KeyPair {
 
 impl Fingerprint for P256KeyPair {
     fn fingerprint(&self) -> String {
-        let codec: &[u8] = &[0x12, 0x0, 0x1];
-        let data = [codec, self.public_key.to_encoded_point(false).as_ref()].concat();
+        let codec: &[u8] = &[0x80, 0x24];
+        let data = [codec, self.public_key.to_encoded_point(true).as_ref()].concat();
         format!("z{}", bs58::encode(data).into_string())
     }
 }
@@ -176,7 +178,9 @@ impl From<P256KeyPair> for KeyPair {
 
 #[cfg(test)]
 pub mod test {
-    use crate::generate;
+    use base64::URL_SAFE;
+
+    use crate::{generate, resolve};
 
     use super::*;
     #[test]
@@ -201,5 +205,28 @@ pub mod test {
         });
 
         println!("{}", serde_json::to_string_pretty(&did_doc).unwrap())
+    }
+
+    #[test]
+    fn resolve_key() {
+        let did_uri = "did:key:zDnaerDaTF5BXEavCrfRZEk316dpbLsfPDZ3WJ5hRTPFU2169";
+
+        let resolved = resolve(did_uri).unwrap();
+
+        matches!(resolved, KeyPair::P256(_));
+    }
+
+    #[test]
+    fn from_secret_key() {
+        let sk = base64::decode_config("gPh-VvVS8MbvKQ9LSVVmfnxnKjHn4Tqj0bmbpehRlpc", URL_SAFE).unwrap();
+
+        let keypair = P256KeyPair::from_secret_key(&sk);
+        let did_doc = keypair.get_did_document(Config::default());
+
+        assert_eq!(
+            keypair.fingerprint(),
+            "zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv"
+        );
+        assert_eq!(did_doc.id, "did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv");
     }
 }

--- a/src/p256.rs
+++ b/src/p256.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use p256::{
     ecdsa::{signature::Signer, signature::Verifier, Signature, SigningKey, VerifyingKey},
-    CompressedPoint, EncodedPoint,
+    EncodedPoint,
 };
 use std::convert::TryFrom;
 
@@ -32,16 +32,6 @@ impl Generate for P256KeyPair {
     }
 
     fn from_public_key(public_key: &[u8]) -> Self {
-        let pk: Vec<u8> = match public_key.len() == 65 {
-            true => public_key.to_vec(),
-            false => {
-                let mut pkk = public_key.to_vec();
-                pkk.insert(0, 0x04);
-                pkk
-            }
-        };
-        let cp = CompressedPoint::from_slice(public_key);
-        let pp = EncodedPoint::from_bytes(public_key);
         P256KeyPair {
             secret_key: None,
             public_key: VerifyingKey::from_encoded_point(&EncodedPoint::from_bytes(public_key).expect("invalid key"))


### PR DESCRIPTION
Fixes #17 