### PR TITLE
18 crate ver bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,19 +16,21 @@ crate-type = [ "lib", "cdylib", "staticlib" ]
 ed25519-dalek = "1.0.1"
 x25519-dalek = "1.1.0"
 curve25519-dalek = "3.0.0"
-bs58 = "0.3.1"
-sha2 = "0.8"
+bs58 = "0.4.0"
+sha2 = "0.9"
 getrandom = { version = "0.2", features = ["js"] }
 pairing-plus = "0.19"
 bbs = { version = "0.4.1", default-features = false }
-hkdf = "0.8"
+hkdf = "0.11"
 arrayref = "0.3"
 did_url = "0.1.0"
 serde = "1.0"
 serde_json = "1.0"
 base64 = "0.13"
-libsecp256k1 = "0.3.5"
+libsecp256k1 = "0.5.0"
 funty = "=1.1.0" # TODO: Remove this, once issue is fixed https://github.com/bitvecto-rs/bitvec/issues/105. Required for `cargo publish`
+# remove after bbs version is updated with latest blake2 and generic-array >= 14
+generic-array = "0.12.4"
 
 [dependencies.p256]
 version = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-key"
-version = "0.0.12"
+version = "0.0.13"
 authors = ["Tomislav Markovski <tomislav@trinsic.id>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/bls12381.rs
+++ b/src/bls12381.rs
@@ -108,7 +108,7 @@ impl Generate for Bls12381KeyPair {
         use sha2::digest::generic_array::{typenum::U48, GenericArray};
 
         let result: &GenericArray<u8, U48> = GenericArray::<u8, U48>::from_slice(secret_key_bytes);
-        let sk = Fr::from_okm(&result);
+        let sk = Fr::from_okm(generic_array::GenericArray::from_slice(result.as_slice()));
 
         let mut pk1 = G1::one();
         pk1.mul_assign(sk);
@@ -295,7 +295,7 @@ fn gen_sk(msg: &[u8]) -> Fr {
     assert!(hkdf::Hkdf::<sha2::Sha256>::new(Some(SALT), &msg_prime[..])
         .expand(&[0, 48], &mut result)
         .is_ok());
-    Fr::from_okm(&result)
+    Fr::from_okm(generic_array::GenericArray::from_slice(result.as_slice()))
 }
 
 #[cfg(test)]

--- a/src/secp256k1.rs
+++ b/src/secp256k1.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 use super::{generate_seed, Ecdh, Ecdsa};
-use secp256k1::{Message, PublicKey, SecretKey, SharedSecret, Signature};
+use libsecp256k1::{Message, PublicKey, SecretKey, SharedSecret, Signature};
 use sha2::{Digest, Sha256};
 
 pub type Secp256k1KeyPair = AsymmetricKey<PublicKey, SecretKey>;
@@ -63,7 +63,7 @@ impl Ecdsa for Secp256k1KeyPair {
                 let signature = match &self.secret_key {
                     Some(sig) => {
                         let message = Message::parse(&get_hash(&payload));
-                        secp256k1::sign(&message, &sig).0
+                        libsecp256k1::sign(&message, &sig).0
                     }
                     None => panic!("secret key not found"),
                 };
@@ -79,9 +79,9 @@ impl Ecdsa for Secp256k1KeyPair {
         match payload {
             Payload::Buffer(payload) => {
                 let message = Message::parse(&get_hash(&payload));
-                let signature = Signature::parse_slice(&signature).expect("Couldn't parse signature");
+                let signature = Signature::parse_standard_slice(&signature).expect("Couldn't parse signature");
 
-                verified = secp256k1::verify(&message, &signature, &self.public_key);
+                verified = libsecp256k1::verify(&message, &signature, &self.public_key);
             }
             _ => unimplemented!("payload type not supported for this key"),
         }


### PR DESCRIPTION
- crates versions updates:
    bs58
    sha2
    hkdf
    libsecp256k1
- added `generic-array` as direct dependency to fix issues with version difference coming from `bbs` crate;
- minor version bumped to `0.0.13`