### PR TITLE
Remove BBS dependency and incorrect signature format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,28 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
-name = "as-slice"
+name = "atomic-polyfill"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+checksum = "e686d748538a32325b28d6411dd8a939e7ad5128e5d0023cc4fd3573db456042"
 dependencies = [
- "generic-array 0.12.4",
- "generic-array 0.13.3",
- "generic-array 0.14.4",
- "stable_deref_trait",
+ "critical-section",
+ "riscv-target",
 ]
 
 [[package]]
@@ -38,6 +45,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "bare-metal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
+dependencies = [
+ "rustc_version 0.2.3",
+]
+
+[[package]]
+name = "bare-metal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
+
+[[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,6 +72,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bit_field"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
+
+[[package]]
+name = "bitfield"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,9 +91,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
-version = "0.20.4"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
+checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
 dependencies = [
  "funty",
  "radium",
@@ -73,37 +107,37 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
-name = "bls"
-version = "0.1.0"
-source = "git+https://github.com/mikelodder7/bls-signatures#fb3cc417c2c2416d462d2758dfd4feb6e2b2569a"
+name = "bls12_381_plus"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14072e323786a34a18e1bf1ef8940fff0537cc45f1f35ad96d4921008c18a88a"
 dependencies = [
- "bls12_381_plus",
- "ff 0.9.0",
- "group 0.9.0",
- "hkdf 0.10.0",
- "pairing",
+ "digest",
+ "ff 0.10.1",
+ "group 0.10.0",
+ "heapless",
+ "pairing 0.20.0",
  "rand_core 0.6.3",
  "serde",
- "sha2",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "bls12_381_plus"
-version = "0.4.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0bf745c8faeaa32fcd7a752e31d18e80ed15c6764072343d6623aa6507ac38"
+checksum = "2d9ca230350e9fa6d2bcbf2eec0dd805a8aa0996ee8884da282097ca7e50a29b"
 dependencies = [
  "digest",
- "ff 0.9.0",
- "group 0.9.0",
+ "ff 0.11.0",
+ "group 0.11.0",
  "heapless",
- "pairing",
+ "pairing 0.21.0",
  "rand_core 0.6.3",
  "serde",
  "subtle",
@@ -118,9 +152,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -130,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byteorder"
@@ -146,7 +180,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -157,9 +191,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags",
  "textwrap",
@@ -168,9 +202,21 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
+checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
+
+[[package]]
+name = "cortex-m"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ff967e867ca14eba0c34ac25cd71ea98c678e741e3915d923999bb2fe7c826"
+dependencies = [
+ "bare-metal 0.2.5",
+ "bitfield",
+ "embedded-hal",
+ "volatile-register",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -218,10 +264,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.1"
+name = "critical-section"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "01e191a5a6f6edad9b679777ef6b6c0f2bdd4a333f2ecb8f61c3e28109a03d70"
+dependencies = [
+ "bare-metal 1.0.0",
+ "cfg-if",
+ "cortex-m",
+ "riscv",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -240,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -253,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -269,11 +327,11 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.4"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc209804a22c34a98fe26a32d997ac64d4284816f65cf1a529c4e31a256218a0"
+checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
  "rand_core 0.6.3",
  "subtle",
  "zeroize",
@@ -285,17 +343,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.4",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
-dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
  "subtle",
 ]
 
@@ -305,7 +353,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
  "subtle",
 ]
 
@@ -317,7 +365,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -346,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.1"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e21d2d0f22cde6e88694108429775c0219760a07779bf96503b434a03d7412"
+checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
 dependencies = [
  "const-oid",
 ]
@@ -359,20 +407,20 @@ version = "0.1.0"
 dependencies = [
  "arrayref",
  "base64 0.13.0",
- "bls",
- "bls12_381_plus",
+ "bls12_381_plus 0.6.0",
  "bs58",
  "criterion",
  "curve25519-dalek",
  "did_url",
  "ed25519-dalek",
  "getrandom 0.2.3",
- "hkdf 0.11.0",
+ "hkdf",
  "libsecp256k1",
  "p256",
  "serde",
  "serde_json",
  "sha2",
+ "signature_bls",
  "x25519-dalek",
 ]
 
@@ -391,7 +439,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array",
 ]
 
 [[package]]
@@ -408,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
+checksum = "74e1069e39f1454367eb2de793ed062fac4c35c2934b76a81d90dd9abcd28816"
 dependencies = [
  "signature",
 ]
@@ -443,7 +491,7 @@ checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
 dependencies = [
  "crypto-bigint",
  "ff 0.10.1",
- "generic-array 0.14.4",
+ "generic-array",
  "group 0.10.0",
  "pkcs8",
  "rand_core 0.6.3",
@@ -452,14 +500,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ff"
-version = "0.9.0"
+name = "embedded-hal"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a4d941a5b7c2a75222e2d44fcdf634a67133d9db31e177ae5ff6ecda852bfe"
+checksum = "e36cfb62ff156596c892272f3015ef952fe1525e85261fa3a7f327bd6b384ab9"
 dependencies = [
- "bitvec",
- "rand_core 0.6.3",
- "subtle",
+ "nb 0.1.3",
+ "void",
 ]
 
 [[package]]
@@ -468,6 +515,18 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
 dependencies = [
+ "bitvec",
+ "rand_core 0.6.3",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
+dependencies = [
+ "bitvec",
  "rand_core 0.6.3",
  "subtle",
 ]
@@ -484,33 +543,15 @@ dependencies = [
 
 [[package]]
 name = "funty"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
 name = "generic-array"
-version = "0.12.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -542,51 +583,52 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3c1e8b4f1ca07e6605ea1be903a5f6956aec5c8a67fd44d56076631675ed8"
-dependencies = [
- "byteorder",
- "ff 0.9.0",
- "rand_core 0.6.3",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
+ "byteorder",
  "ff 0.10.1",
  "rand_core 0.6.3",
  "subtle",
 ]
 
 [[package]]
-name = "half"
-version = "1.7.1"
+name = "group"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
+dependencies = [
+ "byteorder",
+ "ff 0.11.0",
+ "rand_core 0.6.3",
+ "subtle",
+]
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hash32"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
 ]
 
 [[package]]
 name = "heapless"
-version = "0.6.1"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422"
+checksum = "7e476c64197665c3725621f0ac3f9e5209aa5e889e02a08b1daf5f16dc5fd952"
 dependencies = [
- "as-slice",
- "generic-array 0.14.4",
+ "atomic-polyfill",
  "hash32",
+ "spin",
  "stable_deref_trait",
 ]
 
@@ -597,16 +639,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "hkdf"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
-dependencies = [
- "digest",
- "hmac 0.10.1",
 ]
 
 [[package]]
@@ -631,16 +663,6 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
-dependencies = [
- "crypto-mac 0.10.1",
- "digest",
-]
-
-[[package]]
-name = "hmac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
@@ -656,15 +678,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest",
- "generic-array 0.14.4",
+ "generic-array",
  "hmac 0.8.1",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -676,10 +698,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
-name = "js-sys"
-version = "0.3.53"
+name = "itoa"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
+name = "js-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -692,9 +720,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libsecp256k1"
@@ -745,6 +773,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,12 +804,27 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "nb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
+dependencies = [
+ "nb 1.0.0",
+]
+
+[[package]]
+name = "nb"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "num-traits"
@@ -785,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -818,12 +870,20 @@ dependencies = [
 
 [[package]]
 name = "pairing"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be899ebf10363f018353dba1baabb7e83145f3683c7b83b73b93b563e3167cc"
+checksum = "7de9d09263c9966e8196fe0380c9dbbc7ea114b5cf371ba29004bc1f9c6db7f3"
 dependencies = [
- "ff 0.9.0",
- "group 0.9.0",
+ "group 0.10.0",
+]
+
+[[package]]
+name = "pairing"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2e415e349a3006dd7d9482cdab1c980a845bed1377777d768cb693a44540b42"
+dependencies = [
+ "group 0.11.0",
 ]
 
 [[package]]
@@ -834,9 +894,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pkcs8"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee84ed13e44dd82689fa18348a49934fa79cc774a344c42fc9b301c71b140a"
+checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
 dependencies = [
  "der",
  "spki",
@@ -872,24 +932,24 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
@@ -908,7 +968,7 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.16",
  "libc",
- "rand_chacha",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
 ]
@@ -921,6 +981,16 @@ checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -981,6 +1051,8 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -997,19 +1069,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "riscv"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6907ccdd7a31012b70faf2af85cd9e5ba97657cc3987c4f13f8e4d2c2a088aba"
+dependencies = [
+ "bare-metal 1.0.0",
+ "bit_field",
+ "riscv-target",
+]
+
+[[package]]
+name = "riscv-target"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88aa938cda42a0cf62a20cfe8d139ff1af20c2e681212b5b34adb5a58333f222"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.4",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "same-file"
@@ -1028,16 +1130,41 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
-name = "serde"
-version = "1.0.130"
+name = "semver-parser"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "serde"
+version = "1.0.133"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18b20e7752957bbe9661cff4e0bb04d183d0948cdab2ea58cdb9df36a61dfe62"
+dependencies = [
+ "serde",
  "serde_derive",
 ]
 
@@ -1053,9 +1180,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1064,20 +1191,20 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.9.6"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9204c41a1597a8c5af23c82d1c921cb01ec0a4c59e07a9c7306062829a3903f3"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer",
  "cfg-if",
@@ -1088,19 +1215,47 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
+checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
 dependencies = [
  "digest",
  "rand_core 0.6.3",
 ]
 
 [[package]]
-name = "spki"
-version = "0.4.0"
+name = "signature_bls"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
+checksum = "e2b7cca12d2cd1d6d2fffa0375cfc94485acc2a871fc82ac77393487132b5456"
+dependencies = [
+ "bls12_381_plus 0.5.2",
+ "ff 0.10.1",
+ "group 0.10.0",
+ "hkdf",
+ "pairing 0.20.0",
+ "rand_core 0.6.3",
+ "serde",
+ "sha2",
+ "subtle",
+ "vsss-rs",
+ "zeroize",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
 dependencies = [
  "der",
 ]
@@ -1119,9 +1274,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1130,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1167,15 +1322,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -1184,10 +1339,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
-name = "version_check"
-version = "0.9.3"
+name = "vcell"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "volatile-register"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
+dependencies = [
+ "vcell",
+]
+
+[[package]]
+name = "vsss-rs"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f509df857e50af93bea4921d55f66a719d2b5f1f6d066abe7f21800448d09ca"
+dependencies = [
+ "ff 0.10.1",
+ "group 0.10.0",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "serde",
+ "serde-big-array",
+ "sha2",
+ "zeroize",
+]
 
 [[package]]
 name = "walkdir"
@@ -1214,9 +1406,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1224,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1239,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1249,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1262,15 +1454,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "web-sys"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1309,9 +1501,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wyz"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x25519-dalek"
@@ -1326,18 +1521,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.1.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
+checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "did-key"
-version = "0.0.15"
+version = "0.1.0"
 dependencies = [
  "arrayref",
  "base64 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,25 +3,22 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.4",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "atty"
@@ -41,21 +38,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "backtrace"
-version = "0.3.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
-
-[[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,39 +50,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
-name = "bbs"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e24ff98879bedb7fe7b3ce0c86268baca8468e8ce405d44459dbaf0b26ac9ca"
-dependencies = [
- "arrayref",
- "blake2",
- "failure",
- "ff-zeroize",
- "hex",
- "hkdf 0.8.0",
- "pairing-plus",
- "rand 0.7.3",
- "serde",
- "zeroize",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "blake2"
-version = "0.8.1"
+name = "bitvec"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
+checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
 dependencies = [
- "byte-tools",
- "crypto-mac 0.7.0",
- "digest 0.8.1",
- "opaque-debug 0.2.3",
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -110,6 +74,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "generic-array 0.14.4",
+]
+
+[[package]]
+name = "bls"
+version = "0.1.0"
+source = "git+https://github.com/mikelodder7/bls-signatures#fb3cc417c2c2416d462d2758dfd4feb6e2b2569a"
+dependencies = [
+ "bls12_381_plus",
+ "ff 0.9.0",
+ "group 0.9.0",
+ "hkdf 0.10.0",
+ "pairing",
+ "rand_core 0.6.3",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "bls12_381_plus"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0bf745c8faeaa32fcd7a752e31d18e80ed15c6764072343d6623aa6507ac38"
+dependencies = [
+ "digest",
+ "ff 0.9.0",
+ "group 0.9.0",
+ "heapless",
+ "pairing",
+ "rand_core 0.6.3",
+ "serde",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -137,12 +135,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,12 +148,6 @@ checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
  "rustc_version",
 ]
-
-[[package]]
-name = "cc"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 
 [[package]]
 name = "cfg-if"
@@ -289,18 +275,8 @@ checksum = "cc209804a22c34a98fe26a32d997ac64d4284816f65cf1a529c4e31a256218a0"
 dependencies = [
  "generic-array 0.14.4",
  "rand_core 0.6.3",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-dependencies = [
- "generic-array 0.12.4",
- "subtle 1.0.0",
 ]
 
 [[package]]
@@ -310,7 +286,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.4.1",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle",
 ]
 
 [[package]]
@@ -320,7 +306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
@@ -352,9 +338,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
- "digest 0.9.0",
+ "digest",
  "rand_core 0.5.1",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -373,18 +359,17 @@ version = "0.0.15"
 dependencies = [
  "arrayref",
  "base64 0.13.0",
- "bbs",
+ "bls",
+ "bls12_381_plus",
  "bs58",
  "criterion",
  "curve25519-dalek",
  "did_url",
  "ed25519-dalek",
- "generic-array 0.12.4",
  "getrandom 0.2.3",
  "hkdf 0.11.0",
  "libsecp256k1",
  "p256",
- "pairing-plus",
  "serde",
  "serde_json",
  "sha2",
@@ -398,15 +383,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70d5f6334e473e3bb5650ab4ef3e4c910296b76968e62758e7c66157ff767c05"
 dependencies = [
  "form_urlencoded",
-]
-
-[[package]]
-name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.4",
 ]
 
 [[package]]
@@ -447,7 +423,7 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
+ "rand",
  "serde",
  "sha2",
  "zeroize",
@@ -466,35 +442,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
 dependencies = [
  "crypto-bigint",
- "ff",
+ "ff 0.10.1",
  "generic-array 0.14.4",
- "group",
+ "group 0.10.0",
  "pkcs8",
  "rand_core 0.6.3",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
+name = "ff"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+checksum = "72a4d941a5b7c2a75222e2d44fcdf634a67133d9db31e177ae5ff6ecda852bfe"
 dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
+ "bitvec",
+ "rand_core 0.6.3",
+ "subtle",
 ]
 
 [[package]]
@@ -504,33 +469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
 dependencies = [
  "rand_core 0.6.3",
- "subtle 2.4.1",
-]
-
-[[package]]
-name = "ff-zeroize"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02169a2e8515aa316ce516eaaf6318a76617839fbf904073284bc2576b029ee"
-dependencies = [
- "byteorder",
- "ff_derive-zeroize",
- "rand_core 0.5.1",
- "zeroize",
-]
-
-[[package]]
-name = "ff_derive-zeroize"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b24d4059bc0d0a0bf26b740aa21af1f96a984f0ab7a21356d00b32475388b53a"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn",
+ "subtle",
 ]
 
 [[package]]
@@ -544,16 +483,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
+name = "funty"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
 dependencies = [
  "typenum",
 ]
@@ -593,10 +541,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.25.0"
+name = "group"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "61b3c1e8b4f1ca07e6605ea1be903a5f6956aec5c8a67fd44d56076631675ed8"
+dependencies = [
+ "byteorder",
+ "ff 0.9.0",
+ "rand_core 0.6.3",
+ "subtle",
+]
 
 [[package]]
 name = "group"
@@ -604,9 +558,9 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
- "ff",
+ "ff 0.10.1",
  "rand_core 0.6.3",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
@@ -614,6 +568,27 @@ name = "half"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+
+[[package]]
+name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "heapless"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422"
+dependencies = [
+ "as-slice",
+ "generic-array 0.14.4",
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -625,19 +600,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "hkdf"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa08a006102488bd9cd5b8013aabe84955cf5ae22e304c2caf655b633aefae3"
+checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
 dependencies = [
- "digest 0.8.1",
- "hmac 0.7.1",
+ "digest",
+ "hmac 0.10.1",
 ]
 
 [[package]]
@@ -646,18 +615,8 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b"
 dependencies = [
- "digest 0.9.0",
+ "digest",
  "hmac 0.11.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
-dependencies = [
- "crypto-mac 0.7.0",
- "digest 0.8.1",
 ]
 
 [[package]]
@@ -667,7 +626,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
  "crypto-mac 0.8.0",
- "digest 0.9.0",
+ "digest",
+]
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac 0.10.1",
+ "digest",
 ]
 
 [[package]]
@@ -677,7 +646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac 0.11.1",
- "digest 0.9.0",
+ "digest",
 ]
 
 [[package]]
@@ -686,7 +655,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
- "digest 0.9.0",
+ "digest",
  "generic-array 0.14.4",
  "hmac 0.8.1",
 ]
@@ -735,12 +704,12 @@ checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
 dependencies = [
  "arrayref",
  "base64 0.12.3",
- "digest 0.9.0",
+ "digest",
  "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand 0.7.3",
+ "rand",
  "serde",
  "sha2",
  "typenum",
@@ -753,8 +722,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
 dependencies = [
  "crunchy",
- "digest 0.9.0",
- "subtle 2.4.1",
+ "digest",
+ "subtle",
 ]
 
 [[package]]
@@ -806,37 +775,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,25 +794,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opaque-debug"
@@ -894,18 +817,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "pairing-plus"
+name = "pairing"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cda4f22e8e6720f3c254049960c8cc4f93cb82b5ade43bddd2622b5f39ea62"
+checksum = "9be899ebf10363f018353dba1baabb7e83145f3683c7b83b73b93b563e3167cc"
 dependencies = [
- "byteorder",
- "digest 0.8.1",
- "ff-zeroize",
- "rand 0.4.6",
- "rand_core 0.5.1",
- "rand_xorshift",
- "zeroize",
+ "ff 0.9.0",
+ "group 0.9.0",
 ]
 
 [[package]]
@@ -977,17 +895,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.4.6"
+name = "radium"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
@@ -1014,21 +925,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -1050,15 +946,6 @@ name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
 dependencies = [
  "rand_core 0.5.1",
 ]
@@ -1089,15 +976,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,12 +995,6 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc_version"
@@ -1210,8 +1082,8 @@ dependencies = [
  "block-buffer",
  "cfg-if",
  "cpufeatures",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -1220,7 +1092,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
- "digest 0.9.0",
+ "digest",
  "rand_core 0.6.3",
 ]
 
@@ -1234,10 +1106,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "subtle"
-version = "1.0.0"
+name = "stable_deref_trait"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "subtle"
@@ -1267,6 +1139,12 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "textwrap"
@@ -1428,6 +1306,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "x25519-dalek"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "did-key"
-version = "0.0.15"
+version = "0.1.0"
 authors = ["Tomislav Markovski <tomislav@trinsic.id>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,6 @@ base64 = "0.13"
 libsecp256k1 = "0.5.0"
 bls = { git = "https://github.com/mikelodder7/bls-signatures" }
 bls12_381_plus = "0.4"
-# remove after bbs version is updated with latest blake2 and generic-array >= 14
-# generic-array = "0.12.4"
 
 [dependencies.p256]
 version = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ serde = "1.0"
 serde_json = "1.0"
 base64 = "0.13"
 libsecp256k1 = "0.5.0"
-bls = { git = "https://github.com/mikelodder7/bls-signatures" }
-bls12_381_plus = "0.4"
+signature_bls = "0.30.0"
+bls12_381_plus = "0.6"
 
 [dependencies.p256]
 version = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,6 @@ curve25519-dalek = "3.0.0"
 bs58 = "0.4.0"
 sha2 = "0.9"
 getrandom = { version = "0.2", features = ["js"] }
-pairing-plus = "0.19"
-bbs = { version = "0.4.1", default-features = false }
 hkdf = "0.11"
 arrayref = "0.3"
 did_url = "0.1.0"
@@ -28,8 +26,10 @@ serde = "1.0"
 serde_json = "1.0"
 base64 = "0.13"
 libsecp256k1 = "0.5.0"
+bls = { git = "https://github.com/mikelodder7/bls-signatures" }
+bls12_381_plus = "0.4"
 # remove after bbs version is updated with latest blake2 and generic-array >= 14
-generic-array = "0.12.4"
+# generic-array = "0.12.4"
 
 [dependencies.p256]
 version = "0.9.0"

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -32,12 +32,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let payloads: Vec<Buffer> = vec![
         Buffer { data: &[0; 256] },
         Buffer { data: &[0; 1024] },
-        Buffer {
-            data: &[0; 1024 * 1024],
-        },
-        Buffer {
-            data: &[0; 1024 * 1024 * 5],
-        },
+        Buffer { data: &[0; 1024 * 1024] },
+        Buffer { data: &[0; 1024 * 1024 * 5] },
     ];
 
     let ed_key = generate::<Ed25519KeyPair>(None);
@@ -47,23 +43,17 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut group_sign = c.benchmark_group("signatures");
 
     for payload in payloads {
-        group_sign.bench_with_input(
-            BenchmarkId::new("ed sign", payload.data.len()),
-            &payload,
-            |b, &payload| b.iter(|| ed_key.sign(Payload::Buffer(payload.data.to_vec()))),
-        );
+        group_sign.bench_with_input(BenchmarkId::new("ed sign", payload.data.len()), &payload, |b, &payload| {
+            b.iter(|| ed_key.sign(Payload::Buffer(payload.data.to_vec())))
+        });
 
-        group_sign.bench_with_input(
-            BenchmarkId::new("p256 sign", payload.data.len()),
-            &payload,
-            |b, &payload| b.iter(|| p256_key.sign(Payload::Buffer(payload.data.to_vec()))),
-        );
+        group_sign.bench_with_input(BenchmarkId::new("p256 sign", payload.data.len()), &payload, |b, &payload| {
+            b.iter(|| p256_key.sign(Payload::Buffer(payload.data.to_vec())))
+        });
 
-        group_sign.bench_with_input(
-            BenchmarkId::new("bls sign", payload.data.len()),
-            &payload,
-            |b, &payload| b.iter(|| bls_key.sign(Payload::BufferArray(vec![payload.data.to_vec()]))),
-        );
+        group_sign.bench_with_input(BenchmarkId::new("bls sign", payload.data.len()), &payload, |b, &payload| {
+            b.iter(|| bls_key.sign(Payload::BufferArray(vec![payload.data.to_vec()])))
+        });
     }
 
     group_sign.finish();

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -8,7 +8,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     group_key.bench_function("edwards new", |b| b.iter(|| generate::<Ed25519KeyPair>(None)));
     group_key.bench_function("montgomery new", |b| b.iter(|| generate::<X25519KeyPair>(None)));
     group_key.bench_function("p256 new", |b| b.iter(|| generate::<P256KeyPair>(None)));
-    group_key.bench_function("bls new", |b| b.iter(|| generate::<Bls12381KeyPair>(None)));
+    group_key.bench_function("bls new", |b| b.iter(|| generate::<Bls12381KeyPairs>(None)));
 
     group_key.finish();
 
@@ -37,22 +37,22 @@ fn criterion_benchmark(c: &mut Criterion) {
     ];
 
     let ed_key = generate::<Ed25519KeyPair>(None);
-    let bls_key = generate::<Bls12381KeyPair>(None);
+    let bls_key = generate::<Bls12381KeyPairs>(None);
     let p256_key = generate::<P256KeyPair>(None);
 
     let mut group_sign = c.benchmark_group("signatures");
 
     for payload in payloads {
         group_sign.bench_with_input(BenchmarkId::new("ed sign", payload.data.len()), &payload, |b, &payload| {
-            b.iter(|| ed_key.sign(Payload::Buffer(payload.data.to_vec())))
+            b.iter(|| ed_key.sign(payload.data))
         });
 
         group_sign.bench_with_input(BenchmarkId::new("p256 sign", payload.data.len()), &payload, |b, &payload| {
-            b.iter(|| p256_key.sign(Payload::Buffer(payload.data.to_vec())))
+            b.iter(|| p256_key.sign(payload.data))
         });
 
         group_sign.bench_with_input(BenchmarkId::new("bls sign", payload.data.len()), &payload, |b, &payload| {
-            b.iter(|| bls_key.sign(Payload::BufferArray(vec![payload.data.to_vec()])))
+            b.iter(|| bls_key.sign(payload.data))
         });
     }
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-max_width = 120
+max_width = 150

--- a/src/bls12381.rs
+++ b/src/bls12381.rs
@@ -1,6 +1,6 @@
-use bls::{PublicKey, PublicKeyVt, SecretKey, Signature};
 use bls12_381_plus::Scalar;
 use hkdf::HkdfExtract;
+use signature_bls::{PublicKey, PublicKeyVt, SecretKey, Signature};
 
 use crate::{
     didcore::{Config, KeyFormat, JWK},
@@ -229,7 +229,9 @@ fn gen_sk(ikm: &[u8]) -> Option<SecretKey> {
     if let Err(_) = h.expand(&INFO, &mut output) {
         None
     } else {
-        Some(SecretKey(Scalar::from_okm(&output)))
+        let mut bytes = Scalar::from_okm(&output).to_bytes();
+        bytes.reverse();
+        Some(SecretKey::from_bytes(&bytes).unwrap())
     }
 }
 

--- a/src/bls12381.rs
+++ b/src/bls12381.rs
@@ -1,145 +1,83 @@
-use std::convert::TryFrom;
+use bls::{PublicKey, PublicKeyVt, SecretKey};
+use bls12_381_plus::Scalar;
+use hkdf::HkdfExtract;
 
 use crate::{
     didcore::{Config, KeyFormat, JWK},
     generate_seed,
-    traits::Generate,
-    AsymmetricKey, Document, KeyMaterial, KeyPair, Payload, VerificationMethod,
-};
-use crate::{
-    traits::{DIDCore, Ecdh, Ecdsa, Fingerprint},
-    Error,
-};
-use bbs::prelude::*;
-
-use pairing_plus::{
-    bls12_381::{Fr, G1, G2},
-    hash_to_field::BaseFromRO,
-    serdes::SerDes,
-    CurveProjective,
+    traits::{DIDCore, Ecdh, Fingerprint, Generate, SignVerify},
+    Document, Error, KeyMaterial, KeyPair, VerificationMethod,
 };
 
-pub type Bls12381KeyPair = AsymmetricKey<CyclicGroup, SecretKey>;
-
-#[derive(Debug, Clone)]
-pub struct CyclicGroup {
-    pub g1: Vec<u8>,
-    pub g2: DeterministicPublicKey,
+pub struct Bls12381KeyPairs {
+    pk_g1: PublicKeyVt,
+    pk_g2: PublicKey,
+    secret_key: Option<SecretKey>,
 }
 
-impl Bls12381KeyPair {
+impl Bls12381KeyPairs {
     fn get_fingerprint_g1(&self) -> String {
         let codec: &[u8] = &[0xea, 0x1];
-        let data = [codec, self.public_key.g1.as_slice()].concat().to_vec();
+        let data = [codec, &self.pk_g1.to_bytes()[..]].concat().to_vec();
         format!("z{}", bs58::encode(data).into_string())
     }
 
     fn get_fingerprint_g2(&self) -> String {
         let codec: &[u8] = &[0xeb, 0x1];
-        let data = [codec, self.public_key.g2.to_bytes_compressed_form().as_ref()]
-            .concat()
-            .to_vec();
+        let data = [codec, &self.pk_g2.to_bytes()[..]].concat().to_vec();
         format!("z{}", bs58::encode(data).into_string())
     }
 }
 
-impl Ecdsa for Bls12381KeyPair {
-    fn sign(&self, payload: Payload) -> Vec<u8> {
-        let messages: Vec<SignatureMessage> = match payload {
-            Payload::Buffer(_) => unimplemented!("payload type not supported"),
-            Payload::BufferArray(m) => m.iter().map(|x| SignatureMessage::hash(x)).collect(),
-        };
-        let dpk = DeterministicPublicKey::try_from(self.public_key.g2).unwrap();
-        let pk = dpk.to_public_key(messages.len()).unwrap();
-        match &self.secret_key {
-            Some(sk) => Signature::new(&messages, sk, &pk),
-            None => panic!("secret key not found"),
-        }
-        .unwrap()
-        .to_bytes_compressed_form()
-        .to_vec()
+impl SignVerify for Bls12381KeyPairs {
+    fn sign(&self, payload: &[u8]) -> Vec<u8> {
+        unimplemented!()
     }
 
-    fn verify(&self, payload: Payload, signature: &[u8]) -> Result<(), Error> {
-        let messages: Vec<SignatureMessage> = match payload {
-            Payload::Buffer(_) => unimplemented!("payload type not supported"),
-            Payload::BufferArray(m) => m.iter().map(|x| SignatureMessage::hash(x)).collect(),
-        };
-
-        let pk = self.public_key.g2.to_public_key(messages.len()).unwrap();
-        let sig = match Signature::try_from(signature) {
-            Ok(sig) => sig,
-            Err(_) => return Err(Error::Unknown("unable to parse signature".into())),
-        };
-
-        match sig.verify(&messages, &pk) {
-            Ok(x) => {
-                if x {
-                    Ok(())
-                } else {
-                    Err(Error::Unknown("invalid signature".into()))
-                }
-            }
-            Err(_) => Err(Error::Unknown("unexpected error".into())),
-        }
+    fn verify(&self, payload: &[u8], signature: &[u8]) -> Result<(), Error> {
+        unimplemented!()
     }
 }
 
-impl Generate for Bls12381KeyPair {
-    fn new() -> Bls12381KeyPair {
+impl Generate for Bls12381KeyPairs {
+    fn new() -> Bls12381KeyPairs {
         generate_keypair(None)
     }
 
-    fn new_with_seed(seed: &[u8]) -> Bls12381KeyPair {
+    fn new_with_seed(seed: &[u8]) -> Bls12381KeyPairs {
         generate_keypair(Some(seed.into()))
     }
 
-    fn from_public_key(public_key: &[u8]) -> Bls12381KeyPair {
-        Bls12381KeyPair {
-            secret_key: None,
-            public_key: CyclicGroup {
-                g1: public_key[..48].to_vec(),
-                g2: DeterministicPublicKey::try_from(public_key[48..].to_vec()).unwrap(),
-            },
-        }
+    fn from_public_key(public_key: &[u8]) -> Bls12381KeyPairs {
+        unimplemented!("cannot use this construction method")
     }
 
-    fn from_secret_key(secret_key_bytes: &[u8]) -> Bls12381KeyPair {
-        let sk = SecretKey::try_from(secret_key_bytes.to_vec()).unwrap();
-        let (pk2, _) = DeterministicPublicKey::new(Some(KeyGenOption::FromSecretKey(sk.clone())));
+    fn from_secret_key(secret_key_bytes: &[u8]) -> Bls12381KeyPairs {
+        let bytes: [u8; 32] = [0; 32];
+        bytes.copy_from_slice(secret_key_bytes);
 
-        let mut secret_key_bytes = secret_key_bytes.clone();
-        let secret_key_bytes = Fr::deserialize(&mut secret_key_bytes, true).unwrap();
-        let mut pk = G1::one();
-        pk.mul_assign(secret_key_bytes);
+        let sk = SecretKey::from_bytes(&bytes).unwrap();
+        let pk_g1 = PublicKeyVt::from(&sk);
+        let pk_g2 = PublicKey::from(&sk);
 
-        let mut pk1 = vec![];
-        pk.serialize(&mut pk1, true).unwrap();
-
-        Bls12381KeyPair {
-            public_key: CyclicGroup { g1: pk1, g2: pk2 },
-            secret_key: Some(SecretKey::from(sk)),
+        Bls12381KeyPairs {
+            pk_g1: pk_g1,
+            pk_g2: pk_g2,
+            secret_key: Some(sk),
         }
     }
 }
-impl KeyMaterial for Bls12381KeyPair {
+impl KeyMaterial for Bls12381KeyPairs {
     fn public_key_bytes(&self) -> Vec<u8> {
-        [
-            self.public_key.g1.as_slice(),
-            self.public_key.g2.to_bytes_compressed_form().as_ref(),
-        ]
-        .concat()
-        .to_vec()
+        [self.pk_g1.to_bytes().to_vec(), self.pk_g2.to_bytes().to_vec()].concat().to_vec()
     }
 
     fn private_key_bytes(&self) -> Vec<u8> {
-        self.secret_key
-            .as_ref()
-            .map_or(vec![], |x| x.to_bytes_compressed_form().to_vec())
+        self.secret_key.unwrap().to_bytes().to_vec()
     }
 }
 
-impl DIDCore for Bls12381KeyPair {
+impl DIDCore for Bls12381KeyPairs {
     fn get_verification_methods(&self, config: Config, controller: &str) -> Vec<VerificationMethod> {
         vec![
             VerificationMethod {
@@ -154,10 +92,7 @@ impl DIDCore for Bls12381KeyPair {
                     true => KeyFormat::JWK(JWK {
                         key_type: "EC".into(),
                         curve: "BLS12381_G1".into(),
-                        x: Some(base64::encode_config(
-                            self.public_key.g1.as_slice(),
-                            base64::URL_SAFE_NO_PAD,
-                        )),
+                        x: Some(base64::encode_config(self.public_key.g1.as_slice(), base64::URL_SAFE_NO_PAD)),
                         ..Default::default()
                     }),
                 }),
@@ -166,10 +101,7 @@ impl DIDCore for Bls12381KeyPair {
                     true => KeyFormat::JWK(JWK {
                         key_type: "EC".into(),
                         curve: "BLS12381_G1".into(),
-                        x: Some(base64::encode_config(
-                            self.public_key.g1.as_slice(),
-                            base64::URL_SAFE_NO_PAD,
-                        )),
+                        x: Some(base64::encode_config(self.public_key.g1.as_slice(), base64::URL_SAFE_NO_PAD)),
                         d: Some(base64::encode_config(self.private_key_bytes(), base64::URL_SAFE_NO_PAD)),
                         ..Default::default()
                     }),
@@ -184,9 +116,7 @@ impl DIDCore for Bls12381KeyPair {
                 },
                 controller: controller.to_string(),
                 public_key: Some(match config.use_jose_format {
-                    false => {
-                        KeyFormat::Base58(bs58::encode(self.public_key.g2.to_bytes_compressed_form()).into_string())
-                    }
+                    false => KeyFormat::Base58(bs58::encode(self.public_key.g2.to_bytes_compressed_form()).into_string()),
                     true => KeyFormat::JWK(JWK {
                         key_type: "EC".into(),
                         curve: "BLS12381_G2".into(),
@@ -235,7 +165,7 @@ impl DIDCore for Bls12381KeyPair {
     }
 }
 
-impl Fingerprint for Bls12381KeyPair {
+impl Fingerprint for Bls12381KeyPairs {
     fn fingerprint(&self) -> String {
         let codec: &[u8] = &[0xee, 0x1];
         let data = [
@@ -249,56 +179,47 @@ impl Fingerprint for Bls12381KeyPair {
     }
 }
 
-impl Ecdh for Bls12381KeyPair {
+impl Ecdh for Bls12381KeyPairs {
     fn key_exchange(&self, _: &Self) -> Vec<u8> {
         unimplemented!("ECDH is not supported for this key type")
     }
 }
 
-impl From<Bls12381KeyPair> for KeyPair {
-    fn from(key_pair: Bls12381KeyPair) -> Self {
+impl From<Bls12381KeyPairs> for KeyPair {
+    fn from(key_pair: Bls12381KeyPairs) -> Self {
         KeyPair::Bls12381G1G2(key_pair)
     }
 }
 
-fn generate_keypair(seed: Option<Vec<u8>>) -> Bls12381KeyPair {
+fn generate_keypair(seed: Option<Vec<u8>>) -> Bls12381KeyPairs {
     let seed_data = generate_seed(seed.map_or(vec![], |x| x).as_slice()).unwrap();
+    let sk = gen_sk(seed_data.to_vec().as_slice()).unwrap();
 
-    let sk = gen_sk(seed_data.to_vec().as_slice());
-    let mut pk1 = G1::one();
-    pk1.mul_assign(sk);
+    let pk_g1 = PublicKeyVt::from(&sk);
+    let pk_g2 = PublicKey::from(&sk);
 
-    let mut pk1_bytes = Vec::new();
-    pk1.serialize(&mut pk1_bytes, true).unwrap();
-
-    let mut pk2 = G2::one();
-    pk2.mul_assign(sk);
-
-    let mut pk2_bytes = Vec::new();
-    pk2.serialize(&mut pk2_bytes, true).unwrap();
-
-    Bls12381KeyPair {
-        public_key: CyclicGroup {
-            g1: pk1_bytes.to_vec(),
-            g2: DeterministicPublicKey::try_from(pk2_bytes).unwrap(),
-        },
-        secret_key: Some(SecretKey::from(sk)),
+    Bls12381KeyPairs {
+        pk_g1: pk_g1,
+        pk_g2: pk_g2,
+        secret_key: Some(sk),
     }
 }
 
-fn gen_sk(msg: &[u8]) -> Fr {
-    use sha2::digest::generic_array::{typenum::U48, GenericArray};
-    const SALT: &[u8] = b"BLS-SIG-KEYGEN-SALT-";
-    // copy of `msg` with appended zero byte
-    let mut msg_prime = Vec::<u8>::with_capacity(msg.len() + 1);
-    msg_prime.extend_from_slice(msg.as_ref());
-    msg_prime.extend_from_slice(&[0]);
-    // `result` has enough length to hold the output from HKDF expansion
-    let mut result = GenericArray::<u8, U48>::default();
-    assert!(hkdf::Hkdf::<sha2::Sha256>::new(Some(SALT), &msg_prime[..])
-        .expand(&[0, 48], &mut result)
-        .is_ok());
-    Fr::from_okm(generic_array::GenericArray::from_slice(result.as_slice()))
+fn gen_sk(ikm: &[u8]) -> Option<SecretKey> {
+    const SALT: &'static [u8] = b"BLS-SIG-KEYGEN-SALT-";
+    const INFO: [u8; 2] = [0u8, 48u8];
+
+    let mut extracter = HkdfExtract::<sha2::Sha256>::new(Some(SALT));
+    extracter.input_ikm(ikm);
+    extracter.input_ikm(&[0u8]);
+    let (_, h) = extracter.finalize();
+
+    let mut output = [0u8; 48];
+    if let Err(_) = h.expand(&INFO, &mut output) {
+        None
+    } else {
+        Some(SecretKey(Scalar::from_okm(&output)))
+    }
 }
 
 #[cfg(test)]
@@ -311,7 +232,7 @@ pub mod test {
         let keypair = generate_keypair(None);
         let payload = b"secret message".to_vec();
 
-        let signature = keypair.sign(Payload::BufferArray(vec![payload]));
+        let signature = keypair.sign(&payload);
 
         assert_eq!(signature.len(), SIGNATURE_COMPRESSED_SIZE);
     }
@@ -321,9 +242,9 @@ pub mod test {
         let keypair = generate_keypair(None);
         let payload = b"secret message".to_vec();
 
-        let signature = keypair.sign(Payload::BufferArray(vec![payload.clone()]));
+        let signature = keypair.sign(&payload.clone());
 
-        let verify_result = keypair.verify(Payload::BufferArray(vec![payload.clone()]), signature.as_slice());
+        let verify_result = keypair.verify(&payload.clone(), signature.as_slice());
 
         assert!(matches!(verify_result, Ok(_)));
     }
@@ -334,12 +255,9 @@ pub mod test {
         let payload = b"secret message".to_vec();
         let invalid_payload = b"incorrect secret message".to_vec();
 
-        let signature = keypair.sign(Payload::BufferArray(vec![payload.clone()]));
+        let signature = keypair.sign(&payload.clone());
 
-        let verify_result = keypair.verify(
-            Payload::BufferArray(vec![invalid_payload.clone()]),
-            signature.as_slice(),
-        );
+        let verify_result = keypair.verify(&invalid_payload.clone(), signature.as_slice());
 
         assert!(matches!(verify_result, Err(_)));
     }
@@ -349,16 +267,16 @@ pub mod test {
         let keypair = generate_keypair(None);
         let payload = b"secret message".to_vec();
 
-        let signature = keypair.sign(Payload::BufferArray(vec![payload.clone()]));
+        let signature = keypair.sign(&payload.clone());
 
-        let verify_result = keypair.verify(Payload::BufferArray(vec![payload.clone()]), signature[1..].as_ref());
+        let verify_result = keypair.verify(&payload.clone(), signature[1..].as_ref());
 
         assert!(matches!(verify_result, Err(_)));
     }
 
     #[test]
     fn test_generate_public_key() {
-        let key = Bls12381KeyPair::new_with_seed(vec![].as_slice());
+        let key = Bls12381KeyPairs::new_with_seed(vec![].as_slice());
         let pk = key.public_key_bytes();
 
         assert_eq!(G1_COMPRESSED_SIZE + G2_COMPRESSED_SIZE, pk.len());
@@ -366,10 +284,10 @@ pub mod test {
 
     #[test]
     fn test_generate_public_key_from_bytes() {
-        let key = Bls12381KeyPair::new_with_seed(vec![].as_slice());
+        let key = Bls12381KeyPairs::new_with_seed(vec![].as_slice());
         let pk = key.public_key_bytes();
 
-        let actual = Bls12381KeyPair::from_public_key(&pk);
+        let actual = Bls12381KeyPairs::from_public_key(&pk);
         let pk1 = actual.public_key_bytes();
 
         assert_eq!(pk, pk1);
@@ -377,7 +295,7 @@ pub mod test {
 
     #[test]
     fn test_resolve() {
-        let key = crate::generate::<Bls12381KeyPair>(None);
+        let key = crate::generate::<Bls12381KeyPairs>(None);
         let doc = key.get_did_document(CONFIG_LD_PRIVATE);
         let g2 = doc.authentication.unwrap()[1].clone();
 
@@ -390,11 +308,11 @@ pub mod test {
 
     #[test]
     fn secret_key_size() {
-        let key = Bls12381KeyPair::new();
+        let key = Bls12381KeyPairs::new();
         let sk_bytes = key.private_key_bytes();
 
         assert_eq!(sk_bytes.len(), 32);
-        let key = Bls12381KeyPair::from_secret_key(&sk_bytes);
+        let key = Bls12381KeyPairs::from_secret_key(&sk_bytes);
         assert_eq!(key.private_key_bytes().len(), 32)
     }
 }

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -1,9 +1,9 @@
-use super::{generate_seed, Ecdsa};
+use super::{generate_seed, SignVerify};
 use crate::{
     didcore::{Config, Document, KeyFormat, VerificationMethod, JWK},
     traits::{DIDCore, Ecdh, Fingerprint, Generate},
     x25519::X25519KeyPair,
-    AsymmetricKey, Error, KeyMaterial, KeyPair, Payload,
+    AsymmetricKey, Error, KeyMaterial, KeyPair,
 };
 use curve25519_dalek::edwards::CompressedEdwardsY;
 use ed25519_dalek::*;
@@ -98,11 +98,7 @@ impl DIDCore for Ed25519KeyPair {
                     }),
                 }),
             },
-            self.get_x25519()
-                .get_verification_methods(config, controller)
-                .first()
-                .unwrap()
-                .to_owned(),
+            self.get_x25519().get_verification_methods(config, controller).first().unwrap().to_owned(),
         ]
     }
 
@@ -170,28 +166,22 @@ impl KeyMaterial for Ed25519KeyPair {
     }
 }
 
-impl Ecdsa for Ed25519KeyPair {
-    fn sign(&self, payload: Payload) -> Vec<u8> {
+impl SignVerify for Ed25519KeyPair {
+    fn sign(&self, payload: &[u8]) -> Vec<u8> {
         let esk: ExpandedSecretKey = match &self.secret_key {
             Some(x) => x,
             None => panic!("secret key not found"),
         }
         .into();
 
-        match payload {
-            Payload::Buffer(payload) => esk.sign(payload.as_slice(), &self.public_key).to_bytes().to_vec(),
-            Payload::BufferArray(_) => unimplemented!("payload type not supported for this key"),
-        }
+        esk.sign(payload, &self.public_key).to_bytes().to_vec()
     }
 
-    fn verify(&self, payload: Payload, signature: &[u8]) -> Result<(), Error> {
+    fn verify(&self, payload: &[u8], signature: &[u8]) -> Result<(), Error> {
         let sig = Signature::try_from(signature).expect("invalid signature data");
-        match payload {
-            Payload::Buffer(payload) => match self.public_key.verify(payload.as_slice(), &sig) {
-                Ok(_) => Ok(()),
-                _ => Err(Error::Unknown("verify failed".into())),
-            },
-            _ => unimplemented!("payload type not supported for this key"),
+        match self.public_key.verify(payload, &sig) {
+            Ok(_) => Ok(()),
+            _ => Err(Error::Unknown("verify failed".into())),
         }
     }
 }
@@ -210,7 +200,7 @@ impl From<Ed25519KeyPair> for KeyPair {
 
 #[cfg(test)]
 pub mod test {
-    use crate::{didcore::CONFIG_LD_PRIVATE, generate, Payload};
+    use crate::{didcore::CONFIG_LD_PRIVATE, generate};
 
     use super::*;
     #[test]
@@ -219,12 +209,12 @@ pub mod test {
         let public_key = "6fioC1zcDPyPEL19pXRS2E4iJ46zH7xP6uSgAaPdwDrx";
 
         let sk = Ed25519KeyPair::from_seed(bs58::decode(secret_key).into_vec().unwrap().as_slice());
-        let message = b"super secret message".to_vec();
+        let message = b"super secret message";
 
-        let signature = sk.sign(Payload::Buffer(message.clone()));
+        let signature = sk.sign(message);
 
         let pk = Ed25519KeyPair::from_public_key(bs58::decode(public_key).into_vec().unwrap().as_slice());
-        let is_valud = pk.verify(Payload::Buffer(message), signature.as_slice());
+        let is_valud = pk.verify(message, signature.as_slice());
 
         assert!(is_valud.map_or(false, |_| true));
     }
@@ -234,13 +224,13 @@ pub mod test {
         let secret_key = "6Lx39RyWn3syuozAe2WiPdAYn1ctMx17t8yrBMGFBmZy";
         let public_key = "6fioC1zcDPyPEL19pXRS2E4iJ46zH7xP6uSgAaPdwDrx";
 
-        let sk = generate::<Ed25519KeyPair>(Some(bs58::decode(secret_key).into_vec().unwrap().as_slice()));
+        let sk = Ed25519KeyPair::new_with_seed(bs58::decode(secret_key).into_vec().unwrap().as_slice());
         let message = b"super secret message";
 
-        let signature = sk.sign(Payload::Buffer(message.to_vec()));
+        let signature = sk.sign(message);
 
         let pk = Ed25519KeyPair::from_public_key(bs58::decode(public_key).into_vec().unwrap().as_slice());
-        let is_valud = pk.verify(Payload::Buffer(message.to_vec()), &signature).unwrap();
+        let is_valud = pk.verify(message, &signature).unwrap();
 
         matches!(is_valud, ());
     }

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -200,7 +200,7 @@ impl From<Ed25519KeyPair> for KeyPair {
 
 #[cfg(test)]
 pub mod test {
-    use crate::{didcore::CONFIG_LD_PRIVATE, generate};
+    use crate::didcore::CONFIG_LD_PRIVATE;
 
     use super::*;
     #[test]

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -1,7 +1,7 @@
-use super::{generate_seed, SignVerify};
+use super::{generate_seed, CoreSign};
 use crate::{
     didcore::{Config, Document, KeyFormat, VerificationMethod, JWK},
-    traits::{DIDCore, Ecdh, Fingerprint, Generate},
+    traits::{DIDCore, Fingerprint, Generate, ECDH},
     x25519::X25519KeyPair,
     AsymmetricKey, Error, KeyMaterial, KeyPair,
 };
@@ -166,7 +166,7 @@ impl KeyMaterial for Ed25519KeyPair {
     }
 }
 
-impl SignVerify for Ed25519KeyPair {
+impl CoreSign for Ed25519KeyPair {
     fn sign(&self, payload: &[u8]) -> Vec<u8> {
         let esk: ExpandedSecretKey = match &self.secret_key {
             Some(x) => x,
@@ -186,7 +186,7 @@ impl SignVerify for Ed25519KeyPair {
     }
 }
 
-impl Ecdh for Ed25519KeyPair {
+impl ECDH for Ed25519KeyPair {
     fn key_exchange(&self, _: &Self) -> Vec<u8> {
         unimplemented!("ECDH is not supported for this key type")
     }

--- a/src/p256.rs
+++ b/src/p256.rs
@@ -75,7 +75,7 @@ impl CoreSign for P256KeyPair {
     fn verify(&self, payload: &[u8], signature: &[u8]) -> Result<(), Error> {
         self.public_key
             .verify(&payload, &Signature::try_from(signature).unwrap())
-            .map_err(|e| Error::SignatureError)
+            .map_err(|_e| Error::SignatureError)
     }
 }
 
@@ -154,7 +154,7 @@ impl From<P256KeyPair> for KeyPair {
 pub mod test {
     use base64::URL_SAFE;
 
-    use crate::{generate, resolve};
+    use crate::resolve;
 
     use super::*;
     #[test]

--- a/src/p256.rs
+++ b/src/p256.rs
@@ -1,7 +1,7 @@
-use super::{generate_seed, SignVerify};
+use super::{generate_seed, CoreSign};
 use crate::{
     didcore::{Config, KeyFormat, JWK},
-    traits::{DIDCore, Ecdh, Fingerprint, Generate, KeyMaterial},
+    traits::{DIDCore, Fingerprint, Generate, KeyMaterial, ECDH},
     AsymmetricKey, Document, Error, KeyPair, VerificationMethod,
 };
 use p256::{
@@ -63,7 +63,7 @@ impl KeyMaterial for P256KeyPair {
     }
 }
 
-impl SignVerify for P256KeyPair {
+impl CoreSign for P256KeyPair {
     fn sign(&self, payload: &[u8]) -> Vec<u8> {
         let signature = match &self.secret_key {
             Some(sig) => sig.sign(&payload),
@@ -138,7 +138,7 @@ impl Fingerprint for P256KeyPair {
     }
 }
 
-impl Ecdh for P256KeyPair {
+impl ECDH for P256KeyPair {
     fn key_exchange(&self, _: &Self) -> Vec<u8> {
         unimplemented!("ECDH not supported for this key type")
     }

--- a/src/secp256k1.rs
+++ b/src/secp256k1.rs
@@ -169,8 +169,6 @@ fn get_hash(payload: &[u8]) -> [u8; 32] {
 
 #[cfg(test)]
 pub mod test {
-    use crate::generate;
-
     use super::*;
 
     //Are these tests sufficient? Or do I need more?

--- a/src/secp256k1.rs
+++ b/src/secp256k1.rs
@@ -4,7 +4,7 @@ use crate::{
     AsymmetricKey, Error, KeyPair,
 };
 
-use super::{generate_seed, Ecdh, SignVerify};
+use super::{generate_seed, CoreSign, ECDH};
 use libsecp256k1::{Message, PublicKey, SecretKey, SharedSecret, Signature};
 use sha2::{Digest, Sha256};
 
@@ -56,7 +56,7 @@ impl KeyMaterial for Secp256k1KeyPair {
     }
 }
 
-impl SignVerify for Secp256k1KeyPair {
+impl CoreSign for Secp256k1KeyPair {
     fn sign(&self, payload: &[u8]) -> Vec<u8> {
         let signature = match &self.secret_key {
             Some(sig) => {
@@ -80,7 +80,7 @@ impl SignVerify for Secp256k1KeyPair {
     }
 }
 
-impl Ecdh for Secp256k1KeyPair {
+impl ECDH for Secp256k1KeyPair {
     fn key_exchange(&self, key: &Self) -> Vec<u8> {
         match &(self.secret_key) {
             Some(x) => SharedSecret::<Sha256>::new(&key.public_key, &x)

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -22,7 +22,7 @@ pub trait Generate: KeyMaterial {
 }
 
 /// Used for Elliptic Curve Digital Signature Algorithm
-pub trait SignVerify {
+pub trait CoreSign {
     /// Performs sign operation
     fn sign(&self, payload: &[u8]) -> Vec<u8>;
     /// Performs verify operation
@@ -30,7 +30,7 @@ pub trait SignVerify {
 }
 
 /// Used for Elliptic-curve Diffie–Hellman key exchange operations
-pub trait Ecdh {
+pub trait ECDH {
     /// Perform key exchange operation
     fn key_exchange(&self, their_public: &Self) -> Vec<u8>;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::{didcore::Config, Document, Error, Payload, VerificationMethod};
+use crate::{didcore::Config, Document, Error, VerificationMethod};
 
 /// Return key material bytes
 pub trait KeyMaterial {
@@ -22,11 +22,11 @@ pub trait Generate: KeyMaterial {
 }
 
 /// Used for Elliptic Curve Digital Signature Algorithm
-pub trait Ecdsa {
+pub trait SignVerify {
     /// Performs sign operation
-    fn sign(&self, payload: Payload) -> Vec<u8>;
+    fn sign(&self, payload: &[u8]) -> Vec<u8>;
     /// Performs verify operation
-    fn verify(&self, payload: Payload, signature: &[u8]) -> Result<(), Error>;
+    fn verify(&self, payload: &[u8], signature: &[u8]) -> Result<(), Error>;
 }
 
 /// Used for Elliptic-curve Diffie–Hellman key exchange operations

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -1,7 +1,7 @@
 use crate::{
     didcore::*,
     ed25519::Ed25519KeyPair,
-    traits::{DIDCore, Ecdsa, Fingerprint, Generate, KeyMaterial},
+    traits::{DIDCore, Fingerprint, Generate, KeyMaterial, SignVerify},
     AsymmetricKey, Error, KeyPair,
 };
 
@@ -70,13 +70,13 @@ impl Ecdh for X25519KeyPair {
     }
 }
 
-impl Ecdsa for X25519KeyPair {
-    fn sign(&self, _: crate::Payload) -> Vec<u8> {
-        unimplemented!("ECDSA is not supported for this key type")
+impl SignVerify for X25519KeyPair {
+    fn sign(&self, _: &[u8]) -> Vec<u8> {
+        unimplemented!("signing is not supported for this key type")
     }
 
-    fn verify(&self, _: crate::Payload, _: &[u8]) -> Result<(), Error> {
-        unimplemented!("ECDSA is not supported for this key type")
+    fn verify(&self, _: &[u8], _: &[u8]) -> Result<(), Error> {
+        unimplemented!("verifiying is not supported for this key type")
     }
 }
 

--- a/src/x25519.rs
+++ b/src/x25519.rs
@@ -1,11 +1,11 @@
 use crate::{
     didcore::*,
     ed25519::Ed25519KeyPair,
-    traits::{DIDCore, Fingerprint, Generate, KeyMaterial, SignVerify},
+    traits::{CoreSign, DIDCore, Fingerprint, Generate, KeyMaterial},
     AsymmetricKey, Error, KeyPair,
 };
 
-use super::{generate_seed, Ecdh};
+use super::{generate_seed, ECDH};
 use std::convert::TryInto;
 use x25519_dalek::{PublicKey, StaticSecret};
 
@@ -61,7 +61,7 @@ impl KeyMaterial for X25519KeyPair {
     }
 }
 
-impl Ecdh for X25519KeyPair {
+impl ECDH for X25519KeyPair {
     fn key_exchange(&self, key: &Self) -> Vec<u8> {
         match &(self.secret_key) {
             Some(x) => x.diffie_hellman(&key.public_key).as_bytes().to_vec(),
@@ -70,7 +70,7 @@ impl Ecdh for X25519KeyPair {
     }
 }
 
-impl SignVerify for X25519KeyPair {
+impl CoreSign for X25519KeyPair {
     fn sign(&self, _: &[u8]) -> Vec<u8> {
         unimplemented!("signing is not supported for this key type")
     }


### PR DESCRIPTION
- This PR removes the incorrectly used BBS signatures in place of BLS core sign.
- BBS dependency switched to https://github.com/mikelodder7/bls-signatures

Caveat:
Due to missing separate implementations for G1 and G2 keys, the combined BlsKeypair actually uses G2 signature.

The sign/verify/key_exchange functionality are added as a convenience functions, so it might make sense to separate them into a non-default feature.