### PR TITLE
Fixed a case-sensitivity error in Secp256k1 -> JWK.  

### DIFF
--- a/src/secp256k1.rs
+++ b/src/secp256k1.rs
@@ -107,7 +107,7 @@ impl DIDCore for Secp256k1KeyPair {
                 false => KeyFormat::Base58(bs58::encode(self.public_key.serialize()).into_string()),
                 true => KeyFormat::JWK(JWK {
                     key_type: "EC".into(),
-                    curve: "Secp256k1".into(),
+                    curve: "secp256k1".into(),
                     x: Some(base64::encode_config(&pk[1..33], base64::URL_SAFE_NO_PAD)),
                     y: Some(base64::encode_config(&pk[33..65], base64::URL_SAFE_NO_PAD)),
                     ..Default::default()
@@ -117,7 +117,7 @@ impl DIDCore for Secp256k1KeyPair {
                 false => KeyFormat::Base58(bs58::encode(self.private_key_bytes()).into_string()),
                 true => KeyFormat::JWK(JWK {
                     key_type: "EC".into(),
-                    curve: "Secp256k1".into(),
+                    curve: "secp256k1".into(),
                     x: Some(base64::encode_config(&pk[1..33], base64::URL_SAFE_NO_PAD)),
                     y: Some(base64::encode_config(&pk[33..65], base64::URL_SAFE_NO_PAD)),
                     d: Some(base64::encode_config(self.private_key_bytes(), base64::URL_SAFE_NO_PAD)),


### PR DESCRIPTION
See https://tools.ietf.org/id/draft-jones-webauthn-secp256k1-00.html

I checked "crv" values for the other key types and they are correct.